### PR TITLE
haxe.Stack => haxe.CallStack for haxe 2.11+

### DIFF
--- a/src/mconsole/Console.hx
+++ b/src/mconsole/Console.hx
@@ -23,7 +23,12 @@ SOFTWARE.
 package mconsole;
 
 import haxe.PosInfos;
+
+#if haxe_211
+import haxe.CallStack;
+#else
 import haxe.Stack;
+#end
 
 /**
 This console implementation assumes the availability of the WebKit console. 

--- a/src/mconsole/StackHelper.hx
+++ b/src/mconsole/StackHelper.hx
@@ -22,7 +22,11 @@ SOFTWARE.
 
 package mconsole;
 
+#if haxe_211
+import haxe.CallStack;
+#else
 import haxe.Stack;
+#end
 
 /**
 A utility class for formatting stack traces as strings.


### PR DESCRIPTION
To avoid the error of StackItem not found.
