### PR TITLE
Fix issue where duplicate trace message was seen on sys targets

### DIFF
--- a/src/mconsole/Console.hx
+++ b/src/mconsole/Console.hx
@@ -232,6 +232,7 @@ class Console
 	{
 		var params = pos.customParams;
 		if (params == null) params = [];
+		else pos.customParams = null;
 		
 		var level = switch (value)
 		{


### PR DESCRIPTION
When prefixing a trace with a log level e.g.

```
trace("warn", "message");
```

the output on sys target would be

```
message,message
```

This was because we're using the original haxe trace function which will also print the `customParams` from the pos infos. Because we process these params in mconsle we don't want to keep them in the PosInfos object.
