### PR TITLE
Undefined defaultPrinter when no_console flag is set

### DIFF
--- a/src/mconsole/Console.hx
+++ b/src/mconsole/Console.hx
@@ -67,6 +67,8 @@ class Console
 	inline public static function profile(?title:String) {}
 	inline public static function profileEnd(?title:String) {}
 
+    public static var defaultPrinter = null;
+
 	#else
 
 	/**


### PR DESCRIPTION
When compiling with the flag no_console, it complains about no defaultPrinter.
Currently, the fix is setting defaultPrinter to null
